### PR TITLE
Fix Firebase storage bucket URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,7 +39,7 @@ const firebaseConfig = {
   apiKey: 'AIzaSyBltatQTniTVY0Fj-seLuc3bpO7JhB5sIs',
   authDomain: 'planttracker-355e2.firebaseapp.com',
   projectId: 'planttracker-355e2',
-  storageBucket: 'planttracker-355e2.firebasestorage.app',
+  storageBucket: 'planttracker-355e2.appspot.com',
   messagingSenderId: '696840995334',
   appId: '1:696840995334:web:ca06037643511a20c8b987',
   measurementId: 'G-WH7NWE0RM2',


### PR DESCRIPTION
## Summary
- update the storageBucket URL in `script.js` to point to `planttracker-355e2.appspot.com`

## Testing
- `git show -U0`

------
https://chatgpt.com/codex/tasks/task_e_684b2d7d1ca0832bbae894f7d137d4d9